### PR TITLE
Add license to code files

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1,20 +1,20 @@
-Copyright (c) Meta Platforms, Inc. and affiliates.
-Copyright (c) FullCtl and affiliates.
-Copyright (c) Cloudflare and affiliates.
-Copyright (c) Amazon.com Inc. or its affiliates.
-Copyright (c) Google and affiliates.
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# Copyright (c) FullCtl and affiliates.
+# Copyright (c) Cloudflare and affiliates.
+# Copyright (c) Amazon.com Inc. or its affiliates.
+# Copyright (c) Google and affiliates.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 openapi: 3.0.3
 info:


### PR DESCRIPTION
We need this signature on top of each code file, from discussion with Legal.

Hopefully this does not break openAPI syntax