### PR TITLE
Refactor API for cleaner RESTful idioms and support pagination and batching

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -51,16 +51,28 @@ paths:
           required: false
           schema:
             $ref: '#/components/schemas/LocationType'
+        - name: max_results
+          in: query
+          description: Hint to paginate the request with the maximum number of results the caller is able to process.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            maximum: 100
+        - name: next_token
+          in: query
+          description: Indication of the offset to retrieve the next page on a previously initiated paginated request.
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/Location'
-
+                $ref: '#/components/responses/ListLocationsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -109,13 +121,28 @@ paths:
           required: false
           schema:
             type: string
+        - name: max_results
+          in: query
+          description: Hint to paginate the request with the maximum number of results the caller is able to process.
+          required: false
+          schema:
+            type: integer
+            default: 0
+            minimum: 0
+            maximum: 100
+        - name: next_token
+          in: query
+          description: Indication of the offset to retrieve the next page on a previously initiated paginated request.
+          required: true
+          schema:
+            type: string
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SessionArray'
+                $ref: '#/components/responses/ListSessionsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -144,6 +171,13 @@ components:
       description: |-
         Add choices
       type: string
+
+    LocationArray:
+      title: Locations
+      description: Array of peering locations
+      type: array
+      items:
+        $ref: '#/components/schemas/Location'
 
     SessionArray:
       title: BGP Sessions
@@ -214,6 +248,26 @@ components:
         - errors
 
   responses:
+    ListLocationsResponse:
+      title: ListLocationsResponse
+      description: Response to a list for locations
+      type: object
+      properties:
+        next_token:
+          type: string
+        locations:
+          $ref: '#/components/schemas/LocationArray'
+
+    ListSessionsResponse:
+      title: ListSessionsResponse
+      description: Response to a list for sessions
+      type: object
+      properties:
+        next_token:
+          type: string
+        sessions:
+          $ref: '#/components/schemas/SessionArray'
+
     ErrorResponse:
       description: API Error response
       content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -34,12 +34,13 @@ paths:
         '400':
           $ref: '#/components/responses/ErrorResponse'
 
-  /list_locations:
+  /locations:
     get:
+      description: Lists all the visible locations to the caller.
       parameters:
         - name: asn
           in: query
-          description: List avaible locations for peering with the given ASN
+          description: List available locations for peering with the given ASN
           required: true
           schema:
             type: integer
@@ -63,9 +64,9 @@ paths:
         '400':
           $ref: '#/components/responses/ErrorResponse'
 
-  /add_sessions:
+  /sessions:
     post:
-      description: Request peering
+      description: Requests a new set of sessions to be created.
       requestBody:
         description: Request to create peering sessions
         content:
@@ -89,8 +90,8 @@ paths:
         '400':
           $ref: '#/components/responses/ErrorResponse'
 
-  /get_status:
     get:
+      description: Lists a set of sessions visible to the caller. Each session in the set contains a summary of its current status.
       parameters:
         - name: asn
           in: query

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -94,13 +94,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SessionArray'
+                $ref: '#/components/responses/CreateSessionsResponse'
         '300':
           description: Request modified or partially accepted
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SessionArray'
+                $ref: '#/components/responses/CreateSessionsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -179,6 +179,36 @@ components:
       items:
         $ref: '#/components/schemas/Location'
 
+    SessionRequestArray:
+      title: BGP Sessions requested
+      description: Array of BGP Sessions requested
+      type: array
+      items:
+        $ref: '#/components/schemas/SessionRequestItem'
+
+    SessionRequestItem:
+      title: BGP Session Request
+      description: BGP Session Request
+      type: object
+      properties:
+        local_asn:
+          type: integer
+        local_ip:
+          type: string
+        peer_asn:
+          type: integer
+        peer_ip:
+          type: string
+        peer_type:
+          type: string
+        md5: # TODO or auth: md5: $key?
+          type: string
+        location:
+          $ref: '#/components/schemas/Location'
+        item_id:
+          type: string
+          description: unique identifier of the session in an aggregate
+
     SessionArray:
       title: BGP Sessions
       description: Array of BGP Sessions
@@ -207,11 +237,14 @@ components:
           $ref: '#/components/schemas/Location'
         status:
           $ref: '#/components/schemas/SessionStatus'
-        uuid:
+        session_id:
           type: string
           description: |-
             unique identifier (also serves as request id)
             Could separate into local_ and peer_?
+        item_id:
+          type: string
+          description: unique identifier of the session in an aggregate
     Error:
       title: Error
       type: object
@@ -247,6 +280,15 @@ components:
         - name
         - errors
 
+  requests:
+    CreateSessionsRequest:
+      title: CreateSessionsRequest
+      description: Response to a request to create sessions
+      type: object
+      properties:
+        sessions:
+          $ref: '#/components/schemas/SessionRequestArray'
+
   responses:
     ListLocationsResponse:
       title: ListLocationsResponse
@@ -257,6 +299,16 @@ components:
           type: string
         locations:
           $ref: '#/components/schemas/LocationArray'
+
+    CreateSessionsResponse:
+      title: CreateSessionsResponse
+      description: Response to a request to create sessions
+      type: object
+      properties:
+        sessions:
+          $ref: '#/components/schemas/SessionArray'
+        errors:
+          $ref: '#/components/schemas/Error'
 
     ListSessionsResponse:
       title: ListSessionsResponse

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -63,6 +63,8 @@ paths:
 
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
 
   /sessions:
     post:
@@ -89,6 +91,8 @@ paths:
                 $ref: '#/components/schemas/SessionArray'
         '400':
           $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
 
     get:
       description: Lists a set of sessions visible to the caller. Each session in the set contains a summary of its current status.
@@ -113,6 +117,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/SessionArray'
         '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
           $ref: '#/components/responses/ErrorResponse'
 
 components:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -115,12 +115,6 @@ paths:
           required: true
           schema:
             type: integer
-        - name: request_id
-          in: query
-          description: request identifier
-          required: false
-          schema:
-            type: string
         - name: max_results
           in: query
           description: Hint to paginate the request with the maximum number of results the caller is able to process.
@@ -146,6 +140,50 @@ paths:
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
+          $ref: '#/components/responses/ErrorResponse'
+
+  /sessions/{session_id}:
+    get:
+      description: Retrieves a given session by it server-generated ID provided on creation.
+      parameters:
+        - name: session_id
+          in: path
+          description: Server-generated stable identifier for the session.
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
+          $ref: '#/components/responses/ErrorResponse'
+
+    delete:
+      description: Requests to turn the session down and delete it from the server.
+      parameters:
+        parameters:
+        - name: session_id
+          in: path
+          description: Server-generated stable identifier for the session.
+          required: true
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Session is scheduled for deletion and no longer usable
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+        '404':
           $ref: '#/components/responses/ErrorResponse'
 
 components:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -142,6 +142,33 @@ paths:
         '403':
           $ref: '#/components/responses/ErrorResponse'
 
+    delete:
+      description: Requests to turn the session down and delete it from the server.
+      requestBody:
+        description: Request to delete peering sessions
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionReferenceArray'
+        required: true
+      responses:
+        '200':
+          description: Sessions are scheduled for deletion and no longer usable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/DeleteSessionsResponse'
+        '300':
+          description: Request modified or partially accepted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/responses/DeleteSessionsResponse'
+        '400':
+          $ref: '#/components/responses/ErrorResponse'
+        '403':
+          $ref: '#/components/responses/ErrorResponse'
+
   /sessions/{session_id}:
     get:
       description: Retrieves a given session by it server-generated ID provided on creation.
@@ -177,8 +204,12 @@ paths:
           schema:
             type: string
       responses:
-        '204':
+        '200':
           description: Session is scheduled for deletion and no longer usable
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Session'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -283,6 +314,25 @@ components:
         item_id:
           type: string
           description: unique identifier of the session in an aggregate
+
+    SessionReferenceArray:
+      title: BGP Session References
+      description: Array of BGP Session References
+      type: array
+      sessions:
+        $ref: '#/components/schemas/SessionReference'
+
+    SessionReference:
+      title: BGP Session Reference
+      description: Reference to univocally identify a BGP Session
+      type: object
+      properties:
+        session_id:
+          type: string
+          description: |-
+            unique identifier (also serves as request id)
+            Could separate into local_ and peer_?
+
     Error:
       title: Error
       type: object
@@ -357,6 +407,16 @@ components:
           type: string
         sessions:
           $ref: '#/components/schemas/SessionArray'
+
+    DeleteSessionsResponse:
+      title: DeleteSessionsResponse
+      description: Response to a request to delete sessions
+      type: object
+      properties:
+        sessions:
+          $ref: '#/components/schemas/SessionArray'
+        errors:
+          $ref: '#/components/schemas/Error'
 
     ErrorResponse:
       description: API Error response

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -63,7 +63,7 @@ paths:
         - name: next_token
           in: query
           description: Indication of the offset to retrieve the next page on a previously initiated paginated request.
-          required: true
+          required: false
           schema:
             type: string
       responses:
@@ -95,12 +95,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/responses/CreateSessionsResponse'
-        '300':
-          description: Request modified or partially accepted
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/CreateSessionsResponse'
         '400':
           $ref: '#/components/responses/ErrorResponse'
         '403':
@@ -127,7 +121,7 @@ paths:
         - name: next_token
           in: query
           description: Indication of the offset to retrieve the next page on a previously initiated paginated request.
-          required: true
+          required: false
           schema:
             type: string
       responses:
@@ -154,12 +148,6 @@ paths:
       responses:
         '200':
           description: Sessions are scheduled for deletion and no longer usable
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/responses/DeleteSessionsResponse'
-        '300':
-          description: Request modified or partially accepted
           content:
             application/json:
               schema:
@@ -274,9 +262,6 @@ components:
           type: string
         location:
           $ref: '#/components/schemas/Location'
-        item_id:
-          type: string
-          description: unique identifier of the session in an aggregate
 
     SessionArray:
       title: BGP Sessions
@@ -311,9 +296,6 @@ components:
           description: |-
             unique identifier (also serves as request id)
             Could separate into local_ and peer_?
-        item_id:
-          type: string
-          description: unique identifier of the session in an aggregate
 
     SessionReferenceArray:
       title: BGP Session References


### PR DESCRIPTION
This PR contains 4 stacked commits to modify the current API proposal to:
- Model locations and sessions as REST resources: Removes the action from the URI for the resource to allow individual referencing and collections of nested resources.
- Model authorization errors when accessing a resource: The current API namespace is shared across all the callers so responses will be filtered by visibility of the caller or denied in the absence of authorization to use the passed input parameters.
- Add pagination to listing of locations and sessions: Implement a paginator over the list of sessions visible to a caller. The paginator is opportunistic as it will return an upper bounded set using the client hint, and opaque as it will make no commitments on the content of the pagination token.
- Disambiguate items in batch processing for sessions: The creation of sessions allows to submit a set of them to treat them as an aggregate when requesting to operate on a certain peering posture. This commit adds a field to the input and output series such that the client can univocally identify which sessions have been processed successfully or not without relying on implicit ordering of the input or result set.